### PR TITLE
fix : 던전입장안하고 다른씬으로 이동시 nullexception나오는부분 수정

### DIFF
--- a/Dungeon/DungeonController.cs
+++ b/Dungeon/DungeonController.cs
@@ -47,8 +47,11 @@ public class DungeonController
 
     public void ExitDungeon()
     {
-        dungeonplayer.ApplyResult();
-        dungeonplayer = null;
+        if (dungeonplayer != null)
+        {
+            dungeonplayer.ApplyResult();
+            dungeonplayer = null;
+        }
     }
 
 


### PR DESCRIPTION
던전스타트씬에서 타운씬으로 이동할때
ExitDungeon 메서드가 생성되지않은 dungeonPlayer 객체를 찾다보니
해당문제발생.
예외처리하였음